### PR TITLE
READY: Add gulp update task to build and copy to manta-frontend

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,6 +19,7 @@ var jscs = require('gulp-jscs');
 var header = require('gulp-header');
 var zip = require('gulp-zip');
 var replace = require('gulp-replace');
+var spawn = require('child_process').spawn;
 
 var CI_MODE = process.env.NODE_ENV === 'ci';
 var prebid = require('./package.json');
@@ -184,4 +185,12 @@ gulp.task('docs', ['clean-docs'], function () {
       gutil.log('jsdoc2md failed:', err.message);
     })
     .pipe(gulp.dest('docs'));
+});
+
+gulp.task('update', function(cb) {
+  var proc = spawn('gulp', ['build', '--adapters', 'manta-adapters.json'], { stdio: 'inherit' });
+  proc.on('close', function() {
+    gulp.src('build/dist/prebid.js').pipe(gulp.dest('../manta-frontend/client/js', { overwrite: true }));
+    cb();
+  });
 });


### PR DESCRIPTION
@Delightend 

Use as follows:
1. Make your changes to manta-adapters.json (or whatever)
2. `gulp udpate` -> this runs `gulp build --adapters manta-adapters.json` and then copies `build/dist/prebid.js` to `client/js` (assuming manta-frontend and prebid are sibling directories on your file systems - if that's not the case, let me know, and we can figure something more sophisticated out).
